### PR TITLE
Feature/shortcuts

### DIFF
--- a/src/ui/tabview/content/WebContent.qml
+++ b/src/ui/tabview/content/WebContent.qml
@@ -86,7 +86,7 @@ TabContent {
     Binding {
         target: page.tab
         property: "loading"
-        value: webview.loadProgress < 100
+        value: page.tab && page.tab.url.toString().length > 0 && webview.loadProgress < 100
     }
 
     Binding {

--- a/src/ui/window/BrowserWindow.qml
+++ b/src/ui/window/BrowserWindow.qml
@@ -60,6 +60,10 @@ FluidWindow {
         tabController.openNewViewRequest(request);
     }
 
+    function findInPage() {
+        searchOverlay.open();
+    }
+
     width: 1024
     height: 640
 
@@ -69,9 +73,14 @@ FluidWindow {
 
 
     ShortcutManager {
+        root: window.root
         tabBar: tabBar
         toolbar: toolbar
         tabsModel: window.tabsModel
+        searchOverlay: searchOverlay
+        onFindInPage: {
+            window.findInPage();
+        }
     }
 
     Drawer {

--- a/src/ui/window/BrowserWindow.qml
+++ b/src/ui/window/BrowserWindow.qml
@@ -60,10 +60,6 @@ FluidWindow {
         tabController.openNewViewRequest(request);
     }
 
-    function findInPage() {
-        searchOverlay.open();
-    }
-
     width: 1024
     height: 640
 
@@ -78,9 +74,6 @@ FluidWindow {
         toolbar: toolbar
         tabsModel: window.tabsModel
         searchOverlay: searchOverlay
-        onFindInPage: {
-            window.findInPage();
-        }
     }
 
     Drawer {

--- a/src/ui/window/ShortcutManager.qml
+++ b/src/ui/window/ShortcutManager.qml
@@ -3,9 +3,19 @@ import core 1.0
 import ".."
 
 Item {
+    id: shortcutManager
+
+    property var root
     property TabsModel tabsModel
     property Toolbar toolbar
     property TabBar tabBar
+    property SearchOverlay searchOverlay
+
+    // when declaring BrowserWindow as property
+    // application fails to load for some reasons
+    // so find in page shortcut will be shared as a signal
+    // as a workaround
+    signal findInPage
 
     function setActiveTabByIndex(idx) {
         if (idx < 0 || idx >= tabsModel.count) {
@@ -169,7 +179,36 @@ Item {
                 toolbar.forceActiveFocus();
             } else if (tabsModel.active.loading) {
                 tabsModel.active.stop();
+            } else if (searchOverlay.showing) {
+                searchOverlay.close();
             }
         }
     }
+
+    Shortcut {
+        autoRepeat: false
+        sequence: "Ctrl+f"
+        onActivated: {
+            findInPage();
+        }
+    }
+
+    Shortcut {
+        autoRepeat: false
+        sequence: "Ctrl+n"
+        onActivated: {
+            var window = root.newWindow();
+            window.showNormal();
+        }
+    }
+
+    Shortcut {
+        autoRepeat: false
+        sequence: "Ctrl+Shift+n"
+        onActivated: {
+            var window = root.newIncognitoWindow();
+            window.showNormal();
+        }
+    }
+
 }

--- a/src/ui/window/ShortcutManager.qml
+++ b/src/ui/window/ShortcutManager.qml
@@ -11,12 +11,6 @@ Item {
     property TabBar tabBar
     property SearchOverlay searchOverlay
 
-    // when declaring BrowserWindow as property
-    // application fails to load for some reasons
-    // so find in page shortcut will be shared as a signal
-    // as a workaround
-    signal findInPage
-
     function setActiveTabByIndex(idx) {
         if (idx < 0 || idx >= tabsModel.count) {
             return;
@@ -189,7 +183,7 @@ Item {
         autoRepeat: false
         sequence: "Ctrl+f"
         onActivated: {
-            findInPage();
+            searchOverlay.open();
         }
     }
 


### PR DESCRIPTION
Hello!

I've added following shortcuts:

- Find in page
- Cancel find in page (Esc while focused on search)
- New window
- New private window

I have encountered strange bug: when I've added BrowserWindow as property to ShortcutManager, application failed to load on the following line:
`engine.rootObjects()[0]->setProperty("webengine", 1);`

root objects list was empty.

@tim-sueberkrueb maybe you know the source of this issue?

As a workaround I had to share find in page shortcut as a signal, handler of a signal I've placed inside browser window.