### PR TITLE
add missing include to fix "src/main/main.cpp:72:25: error

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -25,6 +25,7 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QtQuickControls2/QQuickStyle>
+#include <QQmlContext>
 #include <QDebug>
 
 #include "../core/models/tabsmodel.h"


### PR DESCRIPTION
Add header to fix this:

```
[omv@bongie browser]$ make
clang++ -c -pipe -Os -gdwarf-4 -Wstrict-aliasing=2 -pipe -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fPIC -std=gnu++11 -Wall -W -D_REENTRANT -fPIC -DENABLE_HIGH_DPI_SCALING -DQT_NO_DEBUG -DQT_QUICKCONTROLS2_LIB -DQT_QUICK_LIB -DQT_GUI_LIB -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -I. -isystem /usr/include/qt5 -isystem /usr/include/qt5/QtQuickControls2 -isystem /usr/include/qt5/QtQuick -isystem /usr/include/qt5/QtGui -isystem /usr/include/qt5/QtQml -isystem /usr/include/qt5/QtNetwork -isystem /usr/include/qt5/QtCore -I. -isystem /usr/include/libdrm -I/usr/lib64/qt5/mkspecs/linux-clang -o tabsmodel.o src/core/models/tabsmodel.cpp
clang++ -c -pipe -Os -gdwarf-4 -Wstrict-aliasing=2 -pipe -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fPIC -std=gnu++11 -Wall -W -D_REENTRANT -fPIC -DENABLE_HIGH_DPI_SCALING -DQT_NO_DEBUG -DQT_QUICKCONTROLS2_LIB -DQT_QUICK_LIB -DQT_GUI_LIB -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -I. -isystem /usr/include/qt5 -isystem /usr/include/qt5/QtQuickControls2 -isystem /usr/include/qt5/QtQuick -isystem /usr/include/qt5/QtGui -isystem /usr/include/qt5/QtQml -isystem /usr/include/qt5/QtNetwork -isystem /usr/include/qt5/QtCore -I. -isystem /usr/include/libdrm -I/usr/lib64/qt5/mkspecs/linux-clang -o tab.o src/core/models/tab.cpp
clang++ -c -pipe -Os -gdwarf-4 -Wstrict-aliasing=2 -pipe -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fPIC -std=gnu++11 -Wall -W -D_REENTRANT -fPIC -DENABLE_HIGH_DPI_SCALING -DQT_NO_DEBUG -DQT_QUICKCONTROLS2_LIB -DQT_QUICK_LIB -DQT_GUI_LIB -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -I. -isystem /usr/include/qt5 -isystem /usr/include/qt5/QtQuickControls2 -isystem /usr/include/qt5/QtQuick -isystem /usr/include/qt5/QtGui -isystem /usr/include/qt5/QtQml -isystem /usr/include/qt5/QtNetwork -isystem /usr/include/qt5/QtCore -I. -isystem /usr/include/libdrm -I/usr/lib64/qt5/mkspecs/linux-clang -o downloadsmodel.o src/core/models/downloadsmodel.cpp
In file included from src/core/models/downloadsmodel.cpp:20:
src/core/models/downloadsmodel.h:41:28: warning: 'DownloadsModel::roleNames' hides overloaded virtual function [-Woverloaded-virtual]
    QHash<int, QByteArray> roleNames();
                           ^
/usr/include/qt5/QtCore/qabstractitemmodel.h:241:35: note: hidden overloaded virtual function 'QAbstractItemModel::roleNames' declared here: different qualifiers (const vs none)
    virtual QHash<int,QByteArray> roleNames() const;
                                  ^
1 warning generated.
clang++ -c -pipe -Os -gdwarf-4 -Wstrict-aliasing=2 -pipe -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fPIC -std=gnu++11 -Wall -W -D_REENTRANT -fPIC -DENABLE_HIGH_DPI_SCALING -DQT_NO_DEBUG -DQT_QUICKCONTROLS2_LIB -DQT_QUICK_LIB -DQT_GUI_LIB -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -I. -isystem /usr/include/qt5 -isystem /usr/include/qt5/QtQuickControls2 -isystem /usr/include/qt5/QtQuick -isystem /usr/include/qt5/QtGui -isystem /usr/include/qt5/QtQml -isystem /usr/include/qt5/QtNetwork -isystem /usr/include/qt5/QtCore -I. -isystem /usr/include/libdrm -I/usr/lib64/qt5/mkspecs/linux-clang -o webdownload.o src/core/models/webdownload.cpp
clang++ -c -pipe -Os -gdwarf-4 -Wstrict-aliasing=2 -pipe -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fPIC -std=gnu++11 -Wall -W -D_REENTRANT -fPIC -DENABLE_HIGH_DPI_SCALING -DQT_NO_DEBUG -DQT_QUICKCONTROLS2_LIB -DQT_QUICK_LIB -DQT_GUI_LIB -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -I. -isystem /usr/include/qt5 -isystem /usr/include/qt5/QtQuickControls2 -isystem /usr/include/qt5/QtQuick -isystem /usr/include/qt5/QtGui -isystem /usr/include/qt5/QtQml -isystem /usr/include/qt5/QtNetwork -isystem /usr/include/qt5/QtCore -I. -isystem /usr/include/libdrm -I/usr/lib64/qt5/mkspecs/linux-clang -o settings.o src/core/settings/settings.cpp
clang++ -c -pipe -Os -gdwarf-4 -Wstrict-aliasing=2 -pipe -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fPIC -std=gnu++11 -Wall -W -D_REENTRANT -fPIC -DENABLE_HIGH_DPI_SCALING -DQT_NO_DEBUG -DQT_QUICKCONTROLS2_LIB -DQT_QUICK_LIB -DQT_GUI_LIB -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -I. -isystem /usr/include/qt5 -isystem /usr/include/qt5/QtQuickControls2 -isystem /usr/include/qt5/QtQuick -isystem /usr/include/qt5/QtGui -isystem /usr/include/qt5/QtQml -isystem /usr/include/qt5/QtNetwork -isystem /usr/include/qt5/QtCore -I. -isystem /usr/include/libdrm -I/usr/lib64/qt5/mkspecs/linux-clang -o startconfig.o src/core/settings/startconfig.cpp
clang++ -c -pipe -Os -gdwarf-4 -Wstrict-aliasing=2 -pipe -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fPIC -std=gnu++11 -Wall -W -D_REENTRANT -fPIC -DENABLE_HIGH_DPI_SCALING -DQT_NO_DEBUG -DQT_QUICKCONTROLS2_LIB -DQT_QUICK_LIB -DQT_GUI_LIB -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -I. -isystem /usr/include/qt5 -isystem /usr/include/qt5/QtQuickControls2 -isystem /usr/include/qt5/QtQuick -isystem /usr/include/qt5/QtGui -isystem /usr/include/qt5/QtQml -isystem /usr/include/qt5/QtNetwork -isystem /usr/include/qt5/QtCore -I. -isystem /usr/include/libdrm -I/usr/lib64/qt5/mkspecs/linux-clang -o searchconfig.o src/core/settings/searchconfig.cpp
clang++ -c -pipe -Os -gdwarf-4 -Wstrict-aliasing=2 -pipe -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fPIC -std=gnu++11 -Wall -W -D_REENTRANT -fPIC -DENABLE_HIGH_DPI_SCALING -DQT_NO_DEBUG -DQT_QUICKCONTROLS2_LIB -DQT_QUICK_LIB -DQT_GUI_LIB -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -I. -isystem /usr/include/qt5 -isystem /usr/include/qt5/QtQuickControls2 -isystem /usr/include/qt5/QtQuick -isystem /usr/include/qt5/QtGui -isystem /usr/include/qt5/QtQml -isystem /usr/include/qt5/QtNetwork -isystem /usr/include/qt5/QtCore -I. -isystem /usr/include/libdrm -I/usr/lib64/qt5/mkspecs/linux-clang -o main.o src/main/main.cpp
In file included from src/main/main.cpp:32:
src/main/../core/models/downloadsmodel.h:41:28: warning: 'DownloadsModel::roleNames' hides overloaded virtual function [-Woverloaded-virtual]
    QHash<int, QByteArray> roleNames();
                           ^
/usr/include/qt5/QtCore/qabstractitemmodel.h:241:35: note: hidden overloaded virtual function 'QAbstractItemModel::roleNames' declared here: different qualifiers (const vs none)
    virtual QHash<int,QByteArray> roleNames() const;
                                  ^
src/main/main.cpp:72:25: error: member access into incomplete type 'QQmlContext'
    engine.rootContext()->setContextProperty("Settings", &settings);
                        ^
/usr/include/qt5/QtQml/qqml.h:500:7: note: forward declaration of 'QQmlContext'
class QQmlContext;
      ^
1 warning and 1 error generated.
```