### PR TITLE
Build and upload an AppImage on each git push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ script:
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs -verbose=2
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage -verbose=3
+  - rm ./appdir/io.liri.Browser.png # Workaround for linuxedeloyqt bug
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage -verbose=2
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
   - curl --upload-file ./APPNAME*.AppImage https://transfer.sh/APPNAME-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
   - qmake CONFIG+=use_qt_paths ..
   - make -j4
   - sudo make install
-  - find .
+  - find ..
   - # sudo make INSTALL_ROOT=../../appdir install ; sudo chown -R $USER ../../appdir ; find ../../appdir/
   - cd ../../
   - git clone https://github.com/tim-sueberkrueb/slime-engine

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ install:
 
 script:
   - mkdir -p ./appdir
-  - sudo make install
   - git clone -b develop https://github.com/lirios/fluid
   - cd fluid
   - git submodule update --init
@@ -44,8 +43,8 @@ script:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs -qmldir=. -verbose=2
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs -qmldir=. -qmldir=slime-engine/modules/SlimeEngine/qmldir -verbose=2
   - rm ./appdir/io.liri.Browser.png # Workaround for linuxedeloyqt bug
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage -qmldir=. -verbose=2
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage -qmldir=. -qmldir=slime-engine/modules/SlimeEngine/qmldir -verbose=2
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
   - curl --upload-file ./Liri_Browser*.AppImage https://transfer.sh/Liri_Browser-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs -verbose=2
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage -verbose=3
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
   - curl --upload-file ./APPNAME*.AppImage https://transfer.sh/APPNAME-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,12 @@ script:
   - git clone -b develop https://github.com/lirios/fluid
   - cd fluid
   - git submodule update --init
+  - ./scripts/fetch_icons.sh
   - mkdir build
   - cd build
   - qmake CONFIG+=use_qt_paths ..
   - make -j4
   - sudo make install
-  - find ..
   - # sudo make INSTALL_ROOT=../../appdir install ; sudo chown -R $USER ../../appdir ; find ../../appdir/
   - cd ../../
   - git clone https://github.com/tim-sueberkrueb/slime-engine

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
   - qmake LIRI_INSTALL_PREFIX=/usr ..
   - make -j4
   - sudo make install
-  - sudo make INSTALL_ROOT=../../appdir install ; sudo chown -R $USER ../../appdir ; find ../../appdir/
+  - # sudo make INSTALL_ROOT=../../appdir install ; sudo chown -R $USER ../../appdir ; find ../../appdir/
   - cd ../../
   - git clone https://github.com/tim-sueberkrueb/slime-engine
   - cd slime-engine
@@ -43,8 +43,8 @@ script:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs -qmldir=. -qmldir=slime-engine/modules/SlimeEngine/qmldir -verbose=2
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs -qmldir=. -qmldir=/usr/lib/qml/ -qmldir=slime-engine/modules/SlimeEngine/qmldir -verbose=2
   - rm ./appdir/io.liri.Browser.png # Workaround for linuxedeloyqt bug
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage -qmldir=. -qmldir=slime-engine/modules/SlimeEngine/qmldir -verbose=2
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage -qmldir=. -qmldir=/usr/lib/qml/ -qmldir=slime-engine/modules/SlimeEngine/qmldir -verbose=2
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
   - curl --upload-file ./Liri_Browser*.AppImage https://transfer.sh/Liri_Browser-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,8 @@ script:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs -verbose=2
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs -qmldir=. -verbose=2
   - rm ./appdir/io.liri.Browser.png # Workaround for linuxedeloyqt bug
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage -verbose=2
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage -qmldir=. -verbose=2
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
   - curl --upload-file ./Liri_Browser*.AppImage https://transfer.sh/Liri_Browser-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,50 @@
+cache:
+  directories:
+    - /var/cache/apt/archives/
+  
+language: cpp
+compiler: gcc
+sudo: require
+dist: trusty
+
+before_install:
+  - sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y
+  - sudo apt-get update -qq
+    
+install: 
+  - sudo apt-get -y install qt58base qt58declarative qt58quickcontrols2 qt58svg qt58webengine
+  - source /opt/qt58/bin/qt58-env.sh
+
+script:
+  - mkdir -p ./appdir
+  - sudo make install
+  - git clone -b develop https://github.com/lirios/fluid
+  - cd fluid
+  - git submodule update --init
+  - mkdir build
+  - cd build
+  - qmake LIRI_INSTALL_PREFIX=/usr ..
+  - make -j4
+  - sudo make install
+  - sudo make INSTALL_ROOT=../../appdir install ; sudo chown -R $USER ../../appdir ; find ../../appdir/
+  - cd ../../
+  - git clone https://github.com/tim-sueberkrueb/slime-engine
+  - cd slime-engine
+  - qmake PREFIX=/usr
+  - make -j4
+  - sudo make install
+  - sudo make INSTALL_ROOT=../appdir install ; sudo chown -R $USER ../appdir ; find ../appdir/
+  - cd ../
+  - mkdir build
+  - cd build
+  - qmake LIRI_INSTALL_PREFIX=/usr CONFIG+=QTWEBENGINE_ENABLED ..
+  - make -j4
+  - sudo make INSTALL_ROOT=../appdir install ; sudo chown -R $USER ../appdir ; find ../appdir/
+  - cd ../
+  - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
+  - chmod a+x linuxdeployqt*.AppImage
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
+  - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
+  - curl --upload-file ./APPNAME*.AppImage https://transfer.sh/APPNAME-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,10 @@ script:
   - cd ../../
   - git clone https://github.com/tim-sueberkrueb/slime-engine
   - cd slime-engine
-  - qmake
+  - qmake CONFIG+=use_qt_paths
   - make -j4
   - sudo make install
-  - sudo make INSTALL_ROOT=../appdir install ; sudo chown -R $USER ../appdir ; find ../appdir/
+  - # sudo make INSTALL_ROOT=../appdir install ; sudo chown -R $USER ../appdir ; find ../appdir/
   - cd ../
   - mkdir build
   - cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ script:
   - qmake CONFIG+=use_qt_paths ..
   - make -j4
   - sudo make install
+  - find . | grep Fluid/Controls/icons
+  - find /opt | grep Fluid/Controls/icons
   - # sudo make INSTALL_ROOT=../../appdir install ; sudo chown -R $USER ../../appdir ; find ../../appdir/
   - cd ../../
   - git clone https://github.com/tim-sueberkrueb/slime-engine

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,7 @@ script:
   - qmake CONFIG+=use_qt_paths ..
   - make -j4
   - sudo make install
-  - find . | grep Fluid/Controls/icons
-  - find /opt | grep Fluid/Controls/icons
+  - find .
   - # sudo make INSTALL_ROOT=../../appdir install ; sudo chown -R $USER ../../appdir ; find ../../appdir/
   - cd ../../
   - git clone https://github.com/tim-sueberkrueb/slime-engine

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
   - cd ../../
   - git clone https://github.com/tim-sueberkrueb/slime-engine
   - cd slime-engine
-  - qmake PREFIX=/usr
+  - qmake
   - make -j4
   - sudo make install
   - sudo make INSTALL_ROOT=../appdir install ; sudo chown -R $USER ../appdir ; find ../appdir/

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ before_install:
   - sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y
   - sudo apt-get update -qq
     
-install: 
-  - sudo apt-get -y install qt58base qt58declarative qt58quickcontrols2 qt58svg qt58webengine
+install:
+  - sudo apt-get -y install qt58base qt58declarative qt58quickcontrols2 qt58svg qt58webengine qt58graphicaleffects
   - source /opt/qt58/bin/qt58-env.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,8 @@ script:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs -qmldir=. -qmldir=/usr/lib/qml/ -qmldir=slime-engine/modules/SlimeEngine/qmldir -verbose=2
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs -qmldir=. -qmldir=slime-engine/modules/SlimeEngine/qmldir -verbose=2
   - rm ./appdir/io.liri.Browser.png # Workaround for linuxedeloyqt bug
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage -qmldir=. -qmldir=/usr/lib/qml/ -qmldir=slime-engine/modules/SlimeEngine/qmldir -verbose=2
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage -qmldir=. -qmldir=slime-engine/modules/SlimeEngine/qmldir -verbose=2
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
   - curl --upload-file ./Liri_Browser*.AppImage https://transfer.sh/Liri_Browser-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
   - git submodule update --init
   - mkdir build
   - cd build
-  - qmake LIRI_INSTALL_PREFIX=/usr ..
+  - qmake CONFIG+=use_qt_paths ..
   - make -j4
   - sudo make install
   - # sudo make INSTALL_ROOT=../../appdir install ; sudo chown -R $USER ../../appdir ; find ../../appdir/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 cache:
   directories:
-    - /var/cache/apt/archives/
+    - /var/cache/apt/archives/*.deb
   
 language: cpp
 compiler: gcc
@@ -48,4 +48,4 @@ script:
   - rm ./appdir/io.liri.Browser.png # Workaround for linuxedeloyqt bug
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage -verbose=2
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
-  - curl --upload-file ./APPNAME*.AppImage https://transfer.sh/APPNAME-git.$(git rev-parse --short HEAD)-x86_64.AppImage
+  - curl --upload-file ./Liri_Browser*.AppImage https://transfer.sh/Liri_Browser-git.$(git rev-parse --short HEAD)-x86_64.AppImage


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to a temporary download URL on transfer.sh (available for 14 days). The download URL is toward the end of each Travis CI build log of each build (see below for how to set up automatic uploading to your GitHub Releases page).

For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started) __prior to merging this__, if you haven't already done so.

[Here is an overview](https://github.com/probonopd/AppImageKit/wiki/AppImages) of projects that are already distributing upstream-provided, official AppImages.

__Please note:__ Instead of storing AppImage builds temporarily for 14 days each on transfer.sh, you could use GitHub Releases to store the binaries permanently. This way, they would be visible on the Releases page of your project. This is what I recommend. See https://docs.travis-ci.com/user/deployment/releases/. If you want to do this for continuous builds, also see https://github.com/probonopd/uploadtool.

If you would like to see only one entry for the Pull Request in your project's history, then please enable [this GitHub functionality](https://help.github.com/articles/configuring-commit-squashing-for-pull-requests/) on your repo. It allows you to squash (combine) the commits when merging.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.