### PR TITLE
Workaround to fix QTBUG-67275: respect Enter key for triggering context menu items

### DIFF
--- a/src/ui/tabview/content/WebContent.qml
+++ b/src/ui/tabview/content/WebContent.qml
@@ -102,23 +102,27 @@ TabContent {
         MenuItem {
             enabled: webview.canGoBack
             text: qsTr("Back")
-            onClicked: webview.goBack()
+            onTriggered: webview.goBack()
+            Keys.onReturnPressed: triggered()
         }
 
         MenuItem {
             enabled: webview.canGoForward
             text: qsTr("Forward")
-            onClicked: webview.goForward()
+            onTriggered: webview.goForward()
+            Keys.onReturnPressed: triggered()
         }
 
         MenuItem {
             text: qsTr("Reload")
-            onClicked: webview.reload()
+            onTriggered: webview.reload()
+            Keys.onReturnPressed: triggered()
         }
 
         MenuItem {
             text: qsTr("View page source")
-            onClicked: webview.triggerWebAction(WebEngineView.ViewSource)
+            onTriggered: webview.triggerWebAction(WebEngineView.ViewSource)
+            Keys.onReturnPressed: triggered()
         }
 
         Connections {
@@ -143,35 +147,40 @@ TabContent {
             visible: textContextMenu.isLink
             height: visible ? MenuItem.implicitHeight : 0
             text: qsTr("Open in new tab")
-            onClicked: webview.triggerWebAction(WebEngineView.OpenLinkInNewTab)
+            onTriggered: webview.triggerWebAction(WebEngineView.OpenLinkInNewTab)
+            Keys.onReturnPressed: triggered()
         }
 
         MenuItem {
             visible: textContextMenu.isLink
             height: visible ? MenuItem.implicitHeight : 0
             text: qsTr("Open in new window")
-            onClicked: webview.triggerWebAction(WebEngineView.OpenLinkInNewWindow)
+            onTriggered: webview.triggerWebAction(WebEngineView.OpenLinkInNewWindow)
+            Keys.onReturnPressed: triggered()
         }
 
         MenuItem {
             visible: textContextMenu.isLink
             height: visible ? MenuItem.implicitHeight : 0
             text: qsTr("Open in  private window")
-            onClicked: actionManager.openUrlInNewPrivateWindowRequested(textContextMenu.request.linkUrl)
+            onTriggered: actionManager.openUrlInNewPrivateWindowRequested(textContextMenu.request.linkUrl)
+            Keys.onReturnPressed: triggered()
         }
 
         MenuItem {
             visible: textContextMenu.isLink
             height: visible ? MenuItem.implicitHeight : 0
             text: qsTr("Copy link location")
-            onClicked: webview.triggerWebAction(WebEngineView.CopyLinkToClipboard)
+            onTriggered: webview.triggerWebAction(WebEngineView.CopyLinkToClipboard)
+            Keys.onReturnPressed: triggered()
         }
 
         MenuItem {
             visible: textContextMenu.isLink
             height: visible ? MenuItem.implicitHeight : 0
             text: qsTr("Download link location")
-            onClicked: webview.triggerWebAction(WebEngineView.DownloadLinkToDisk)
+            onTriggered: webview.triggerWebAction(WebEngineView.DownloadLinkToDisk)
+            Keys.onReturnPressed: triggered()
         }
 
         MenuItem {
@@ -179,7 +188,8 @@ TabContent {
             enabled: textContextMenu.isTextSelected
             height: visible ? MenuItem.implicitHeight : 0
             text: qsTr("Cut")
-            onClicked: webview.triggerWebAction(WebEngineView.Cut)
+            onTriggered: webview.triggerWebAction(WebEngineView.Cut)
+            Keys.onReturnPressed: triggered()
         }
 
         MenuItem {
@@ -187,21 +197,24 @@ TabContent {
             enabled: textContextMenu.isTextSelected
             height: visible ? MenuItem.implicitHeight : 0
             text: qsTr("Copy")
-            onClicked: webview.triggerWebAction(WebEngineView.Copy)
+            onTriggered: webview.triggerWebAction(WebEngineView.Copy)
+            Keys.onReturnPressed: triggered()
         }
 
         MenuItem {
             visible: textContextMenu.isEditable
             height: visible ? MenuItem.implicitHeight : 0
             text: qsTr("Paste")
-            onClicked: webview.triggerWebAction(WebEngineView.Paste)
+            onTriggered: webview.triggerWebAction(WebEngineView.Paste)
+            Keys.onReturnPressed: triggered()
         }
 
         MenuItem {
             visible: textContextMenu.isTextSelected || textContextMenu.isEditable
             height: visible ? MenuItem.implicitHeight : 0
             text: qsTr("Select all")
-            onClicked: webview.triggerWebAction(WebEngineView.SelectAll)
+            onTriggered: webview.triggerWebAction(WebEngineView.SelectAll)
+            Keys.onReturnPressed: triggered()
         }
 
         Connections {

--- a/src/ui/window/BrowserWindow.qml
+++ b/src/ui/window/BrowserWindow.qml
@@ -414,19 +414,21 @@ ApplicationWindow {
         MenuItem {
             text: qsTr("New window")
             icon.source: Utils.iconUrl("action/open_in_new")
-            onClicked: {
+            onTriggered: {
                 var window = root.newWindow();
                 window.showNormal();
             }
+            Keys.onReturnPressed: triggered()
         }
 
         MenuItem {
             text: qsTr("Private Window")
             icon.source: Utils.iconUrl("hardware/security")
-            onClicked: {
+            onTriggered: {
                 var window = root.newIncognitoWindow();
                 window.showNormal();
             }
+            Keys.onReturnPressed: triggered()
         }
 
         MenuItem {
@@ -434,34 +436,38 @@ ApplicationWindow {
             icon.source: Utils.iconUrl("action/find_in_page")
             // Disable find in page overlay when there is no open tab
             enabled: !tabController.tabsModel.empty
-            onClicked: {
+            onTriggered: {
                 searchOverlay.open();
             }
+            Keys.onReturnPressed: triggered()
         }
 
         MenuItem {
             text: qsTr("Downloads")
             icon.source: Utils.iconUrl("file/file_download")
-            onClicked: {
+            onTriggered: {
                 rightDrawer.loadContent(rightDrawer.downloads);
                 rightDrawer.open();
             }
+            Keys.onReturnPressed: triggered()
         }
 
         MenuItem {
             text: window.isFullScreen? qsTr("Exit fullscreen") : qsTr("Fullscreen")
             icon.source: Utils.iconUrl(!window.isFullScreen ? "navigation/fullscreen" : "navigation/fullscreen_exit")
-            onClicked: {
+            onTriggered: {
                 toggleFullScreen();
             }
+            Keys.onReturnPressed: triggered()
         }
 
         MenuItem {
             text: qsTr("Settings")
             icon.source: Utils.iconUrl("action/settings")
-            onClicked: {
+            onTriggered: {
                 tabController.openUrl("liri://settings");
             }
+            Keys.onReturnPressed: triggered()
         }
 
         Connections {
@@ -471,6 +477,7 @@ ApplicationWindow {
                 if (empty && searchOverlay.showing)
                     searchOverlay.close();
             }
+            Keys.onReturnPressed: triggered()
         }
 
         Connections {


### PR DESCRIPTION
Right now it's not possible to trigger MenuItems in context menu using Enter key, which is a default behavior for all platforms